### PR TITLE
feat: onOptionAdd, controlled selectedValues & isOpen, improved keyboard

### DIFF
--- a/src/hooks/use-controllable-state.tsx
+++ b/src/hooks/use-controllable-state.tsx
@@ -1,0 +1,26 @@
+import { Dispatch, SetStateAction, useCallback, useState } from "react";
+
+export function useControllableState<T>({
+  value,
+  defaultValue,
+  onChange,
+}: {
+  value?: T;
+  defaultValue: T;
+  onChange?: Dispatch<SetStateAction<T>>;
+}): [T, (next: T | ((prev: T) => T)) => void] {
+  const [internalValue, setInternalValue] = useState<T>(defaultValue);
+  const isControlled = value !== undefined;
+
+  const state = isControlled ? value : internalValue;
+
+  const setState = useCallback(
+    (next: T | ((prev: T) => T)) => {
+      if (!isControlled) setInternalValue(next);
+      onChange?.(next);
+    },
+    [isControlled, onChange]
+  );
+
+  return [state, setState];
+}


### PR DESCRIPTION
### Description of your changes
- incorporating changes used in Kamaji app
- onOptionAdd (input to add new options)
  - Plus button on search/input to indicate fields can be added
- controlled props:
  - selectedValues + setSelectedValues function
  - isOpen (isPopoverOpen + setIsPopOverOpen function)
- improved keyboard controls
  - no longer remove options on search field backspace
  - keyboard controls for adding new options (when onOptionAdd is given)

### Issue ticket number and link
<!--- Please include the JIRA ticket and link -->

### Type of change
- [ ] Bug fix
- [x] New feature
   - [ ] Backwards Incompatible?
- [ ] Refactoring / code clean-up
- [ ] Documentation add / update
- [ ] Automated Test
- [ ] Other (please specify)

### (If applicable) How has this been tested?
Kamaji
